### PR TITLE
ci: enforce joyful commit messages :partying_face:

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,9 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
+      - name: "Check commit message for :partying_face: emoji"
+        run: git log -1 --pretty=%B | grep -q ":partying_face:"
+
       - name: cargo test
         run: cargo test --all-features
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+## Einladung annehmen oder ablehnen
+
 Um die Einladung anzunehmen oder abzulehnen, editiere die `gästeliste.toml` Datei und eröffne einen Pull Request.
 Hier ein Beispiel:
 
@@ -18,3 +20,7 @@ Wenn die Einladung mehrere Personen betrifft muss der Eintrag so aussehen:
 +attending.Foo = ["afternoon", "dinner"]
 +attending.Bar = ["afternoon"]
 ```
+
+## Commit Aussage
+
+Hochzeiten sind freudige Feiern voller Liebe und Glück – und genau dieses Gefühl sollte sich auch in deinen Commits widerspiegeln! Deshalb musst du mindestens ein `:partying_face:` Emoji in deine Commit Aussage integrieren.


### PR DESCRIPTION
* [Example of a successful run](https://github.com/risikofrei/hochzeitsfest/actions/runs/13260247980)
* [Example of a failed run](https://github.com/risikofrei/hochzeitsfest/actions/runs/13260116511/job/37014556598#step:3:41)