### PR TITLE
make data validation more declarative 🥳

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,5 +4,5 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-serde = "1.0.217"
+serde = { version = "1.0.217", features = ["derive"] }
 toml = { version = "0.8.20", default-features = false, features = ["parse"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,32 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GuestList {
+    pub guests: Vec<Guest>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct Guest {
+    pub name: String,
+    pub is_invited_by_paper: bool,
+    pub is_invited_to_hike: bool,
+    pub attending: Option<AttendingField>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum AttendingField {
+    Single(Vec<AttendingValue>),
+    Table(HashMap<String, AttendingField>),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum AttendingValue {
+    Afternoon,
+    Dinner,
+    Hike,
+}

--- a/tests/attending.rs
+++ b/tests/attending.rs
@@ -1,37 +1,38 @@
+use hochzeitsfest::{AttendingField, GuestList};
+
 #[test]
 fn values_are_valid() {
     let input = include_str!("../gästeliste.toml");
-    let root_table: toml::Value = toml::from_str(input).unwrap();
-    let guests = root_table["guests"].as_array().unwrap();
-    for guest in guests {
-        let guest = guest.as_table().unwrap();
-        let Some(attending) = guest.get("attending") else {
+
+    let guest_list: GuestList = toml::from_str(input).unwrap();
+
+    for guest in guest_list.guests {
+        let Some(attending) = guest.attending else {
             // guest has not decided yet
             continue;
         };
 
-        let name = guest["name"].as_str().unwrap();
+        let name = guest.name;
 
         let sub_guests: Vec<&str> = name.split(" und ").flat_map(|g| g.split(", ")).collect();
 
-        fn validate_attending(name: &str, attending: &[toml::Value]) {
-            static ALLOWED_VALUES: &[&str] = &["afternoon", "dinner", "hike"];
-            for val in attending {
-                let val = val.as_str().unwrap();
-                assert!(ALLOWED_VALUES.contains(&val), "{name} violated the law");
+        match attending {
+            AttendingField::Single(_) => assert_eq!(
+                sub_guests.len(),
+                1,
+                "please specify 'attending' for each person individually"
+            ),
+            AttendingField::Table(table) => {
+                for name in table.keys() {
+                    assert!(
+                        sub_guests.contains(&name.as_str()),
+                        "unexpected guest: {name}"
+                    )
+                }
+                for name in sub_guests {
+                    assert!(table.contains_key(name), "missing guest: {name}")
+                }
             }
-        }
-
-        if sub_guests.len() > 1 {
-            for sub_guest in attending.as_table().unwrap() {
-                let name = sub_guest.0.as_str();
-                assert!(sub_guests.contains(&name), "unexpected guest: {name}");
-                let attending = sub_guest.1.as_array().unwrap();
-                validate_attending(name, attending);
-            }
-        } else {
-            let attending = attending.as_array().unwrap();
-            validate_attending(name, attending);
         }
     }
 }


### PR DESCRIPTION
The function `validate_attending` is not necessary anymore, as the validation of these values is now declaratively handled by the definition of the enum `AttendingValue`.