### PR TITLE
ci: improve event triggers

### DIFF
--- a/.github/workflows/ci_checks.yml
+++ b/.github/workflows/ci_checks.yml
@@ -1,4 +1,8 @@
-on: [push]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
 
 env:
   CARGO_TERM_COLOR: always
@@ -12,7 +16,9 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: "Check commit message conventions"
-        run: ./devel/scripts/check_commit_message.sh
+        # This "pull_request" event payload doens't exist on "push" events, but
+        # in that case, HEAD already points to the correct commit to check.
+        run: ./devel/scripts/check_commit_message.sh ${{ github.event.pull_request.head.sha }}
 
       - name: cargo test
         run: cargo test --all-features

--- a/devel/scripts/check_commit_message.sh
+++ b/devel/scripts/check_commit_message.sh
@@ -1,15 +1,23 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# commit to check: first arg or HEAD
+commit_to_check="${1:-$(git rev-parse HEAD)}"
+
+if test -n "${CI+x}" ; then
+    # GitHub CI may not have this ref fetched by default
+    git fetch origin "$commit_to_check"
+fi
+
 echo "Checking commit message for 🥳 emoji..."
-if ! git log -1 --pretty=%B | grep -qE "(:partying_face:|🥳)"
+if ! git log -1 --pretty=%B "$commit_to_check" | grep -qE "(:partying_face:|🥳)"
 then
     echo "Please be more joyful !! 🥳"
     exit 1
 fi
 
 echo "Checking commit message subject length..."
-if (( "$(git log -1 --pretty=%s | wc -c)" > 50 ))
+if (( "$(git log -1 --pretty=%s "$commit_to_check" | wc -c)" > 50 ))
 then
     echo "Please avoid lengthy commit message subjects!"
     echo "https://cbea.ms/git-commit/#limit-50"


### PR DESCRIPTION
- Don't run CI checks on every push anymore. This makes it less annoying to push "work in progress" commits.
- Do run CI checks on every push to the main branch.
- Run CI checks on pull requests.

Documentation of the `pull_request` event trigger for reference: https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request