### PR TITLE
improve error message for invalid data 🥳

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use serde::{Deserialize, Serialize};
+use serde::{de::Visitor, Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct GuestList {
@@ -16,11 +16,52 @@ pub struct Guest {
     pub attending: Option<AttendingField>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(untagged)]
 pub enum AttendingField {
     Single(Vec<AttendingValue>),
-    Table(HashMap<String, AttendingField>),
+    Table(HashMap<String, Vec<AttendingValue>>),
+}
+
+impl<'de> Deserialize<'de> for AttendingField {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(AttendingFieldVisitor)
+    }
+}
+
+struct AttendingFieldVisitor;
+
+impl<'de> Visitor<'de> for AttendingFieldVisitor {
+    type Value = AttendingField;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        formatter.write_str("a list of AttendingValue or a map of strings (names of sub-attendees) to list of AttendingValue")
+    }
+
+    fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+    where
+        A: serde::de::SeqAccess<'de>,
+    {
+        let mut v = Vec::new();
+        while let Some(elem) = seq.next_element()? {
+            v.push(elem);
+        }
+        Ok(AttendingField::Single(v))
+    }
+
+    fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+    where
+        A: serde::de::MapAccess<'de>,
+    {
+        let mut m = HashMap::new();
+        while let Some((name, attending)) = map.next_entry()? {
+            m.insert(name, attending);
+        }
+        Ok(AttendingField::Table(m))
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]


### PR DESCRIPTION
The attribute `#[serde(untagged)]` on the `attending` field is the correct one for how the data was originally modeled, but it comes with a downside. If there is any deserialization error within the `attending` structure, the resulting error message won't be very useful. For example, if there is an incorrect `AttendingValue` like "dINNER", the resulting error will be:

> data did not match any variant of untagged enum AttendingField

The only way to solve this is to add a custom Deserialize implementation that commits to one of the enum variants earlier. In this case, we can commit based on whether the value is a list or a map.

For the above example of "dINNER", the new error message is:

> unknown variant `dINNER`, expected one of `afternoon`, `dinner`, `hike`

This also improves the error message if `attending` is neither a list nor a map, for example `attending = 12`:

> invalid type: integer `12`, expected a list of AttendingValue or a map
> of strings (names of sub-attendees) to list of AttendingValue